### PR TITLE
Update IUSE to include c++0x

### DIFF
--- a/media-gfx/blender/blender-9999.ebuild
+++ b/media-gfx/blender/blender-9999.ebuild
@@ -39,7 +39,7 @@ HOMEPAGE="http://www.blender.org"
 SLOT="0"
 LICENSE="|| ( GPL-2 BL )"
 KEYWORDS=""
-IUSE="+boost +bullet collada colorio cycles +dds debug +elbeem ffmpeg fftw +game-engine jack jpeg2k libav ndof nls openal openimageio +opennl openmp +openexr player redcode sdl sndfile cpu_flags_x86_sse cpu_flags_x86_sse2 tiff"
+IUSE="+boost +bullet c++0x collada colorio cycles +dds debug +elbeem ffmpeg fftw +game-engine jack jpeg2k libav ndof nls openal openimageio +opennl openmp +openexr player redcode sdl sndfile cpu_flags_x86_sse cpu_flags_x86_sse2 tiff"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}
 	player? ( game-engine )
 	redcode? ( jpeg2k ffmpeg )


### PR DESCRIPTION
src_configure checks for whether or not the 'c++0x' USE flag is
specified, and since it's not in IUSE, the ebuild fails there.  This
fixes that.
